### PR TITLE
Added document marker "--CC" to grammar.

### DIFF
--- a/grammars/computercraft.cson
+++ b/grammars/computercraft.cson
@@ -4,6 +4,7 @@ fileTypes: [
 ]
 foldingStartMarker: "^\\s*\\b(function|local\\s+function|if|elseif|for)\\b|{[ \\t]*$|\\[\\["
 foldingStopMarker: "\\bend\\b|^\\s*}|\\]\\]"
+firstLineMatch: "--CC.*"
 name: "ComputerCraft"
 patterns: [
   {


### PR DESCRIPTION
With that change any file with a "--CC" in the first line will be automatically recognized as a ComputerCraft file.
It bugged me a little to always select the right grammar for my scripts because they had no ending.